### PR TITLE
Fix compilation on newer version of elixir

### DIFF
--- a/lib/expr/ops.ex
+++ b/lib/expr/ops.ex
@@ -1,14 +1,8 @@
 defmodule Expr.Ops do
-  
-  alias __MODULE__ 
 
-  def __struct__ do
-    %{
-      :p => nil,
-      :f => nil,
-      :a => :r
-    }
-  end
+  alias __MODULE__
+
+  defstruct p: nil, f: nil, a: :r
 
   def oprs do
     %{"#"     => %Ops{:p => 4, :f => &(&1 * - 1)},
@@ -49,6 +43,6 @@ defmodule Expr.Ops do
   def fact(n, acc), do: fact(n - 1, acc * n)
 
   def fmod(n, denom), do: n - denom * Float.floor( n / denom )
-  
+
 end
 


### PR DESCRIPTION
By the way, the elixir 1.0 supports defstruct, with manually defined struct elixir compiler track it as deadlock:

``` elixir
druss@dar ~/p/expr> mix compile
Compiling 5 files (.ex)

== Compilation error on file lib/expr/parser.ex ==
** (CompileError)  deadlocked waiting on module Expr.Ops
    (elixir) src/elixir_aliases.erl:80: :elixir_aliases.ensure_loaded/3


== Compilation error on file lib/expr/ops.ex ==
** (CompileError)  deadlocked waiting on module Expr.Ops
    (stdlib) lists.erl:1353: :lists.mapfoldl/3


== Compilation error on file lib/expr.ex ==
** (CompileError)  deadlocked waiting on module Expr.Ops
    (elixir) src/elixir_aliases.erl:80: :elixir_aliases.ensure_loaded/3


Compilation failed because of a deadlock between files.
The following files depended on the following modules:

  lib/expr/parser.ex => Expr.Ops
     lib/expr/ops.ex => Expr.Ops
         lib/expr.ex => Expr.Ops

```
